### PR TITLE
Code sniffer and run-scripts added to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
       "bin/phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 --ignore=./tests/coverage/* ./src ./tests;"
     ],
     "fix-style": [
-      "bin/phpcbf --standard=PSR2 --extensions=php ./src ./tests;"
+      "bin/phpcbf --standard=PSR2 --extensions=php --ignore=./tests/coverage/* ./src ./tests;"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     "mockery/mockery": "dev-master",
     "internations/http-mock": "^0.8.1",
     "codacy/coverage": "dev-master",
-    "codeclimate/php-test-reporter": "dev-master"
+    "codeclimate/php-test-reporter": "dev-master",
+    "squizlabs/php_codesniffer": "^3.0"
   },
+  "prefer-stable": true,
   "config": {
     "bin-dir": "bin"
   },
@@ -22,5 +24,13 @@
       "DarrynTen\\XeroOauth\\Tests\\": "tests/"
     },
     "exclude-from-classmap": ["/Tests/"]
+  },
+  "scripts": {
+    "check-style": [
+      "bin/phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests;"
+    ],
+    "fix-style": [
+      "bin/phpcbf --standard=PSR2 --extensions=php ./src ./tests;"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "check-style": [
-      "bin/phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests;"
+      "bin/phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 --ignore=./tests/coverage/* ./src ./tests;"
     ],
     "fix-style": [
       "bin/phpcbf --standard=PSR2 --extensions=php ./src ./tests;"


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | no
| New feature?      | yes
| Breaking Changes? | no
| Fixed issues      | #

## The problem
It was difficult to check code style

## How I resolved it
* Added "squizlabs/php_codesniffer" to composer.json
* Added scripts to run check style (`composer run check-style`) and fix errors (`composer run fix-style`)

## How to verify it
Install package and try commands

## Notes
I've also added `prefer-stable` instruction to composer to avoid installation of unstable versions of packages

Notify the following people: @darrynten 
