### PR TITLE
BaseConfig tests; Minor code fixes: namespaces and variable names

### DIFF
--- a/src/Config/BaseConfig.php
+++ b/src/Config/BaseConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DarrynTen\XeroOauth;
+namespace DarrynTen\XeroOauth\Config;
 
 use DarrynTen\XeroOauth\Exception\ConfigException;
 
@@ -250,7 +250,7 @@ abstract class BaseConfig
     {
         $config = [
             'key' => $this->key,
-            'endpoint' => $this->username,
+            'endpoint' => $this->endpoint,
             // etc
         ];
 

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -12,7 +12,6 @@
 namespace DarrynTen\XeroOauth\Exception;
 
 use Exception;
-use DarrynTen\XeroOauth\Exception\ExceptionMessages;
 
 /**
  * Config exception for XeroOauth
@@ -37,7 +36,7 @@ class ConfigException extends Exception
         $message = sprintf(
             'Config error %s %s',
             $extra,
-            ExceptionMessages::$validationMessages[$code]
+            ExceptionMessages::$modelErrorMessages[$code]
         );
 
         parent::__construct($message, $code);

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -36,7 +36,7 @@ class ConfigException extends Exception
         $message = sprintf(
             'Config error %s %s',
             $extra,
-            ExceptionMessages::$modelErrorMessages[$code]
+            ExceptionMessages::$configErrorMessages[$code]
         );
 
         parent::__construct($message, $code);

--- a/src/Exception/ExceptionMessages.php
+++ b/src/Exception/ExceptionMessages.php
@@ -8,7 +8,7 @@ namespace DarrynTen\XeroOauth\Exception;
 class ExceptionMessages
 {
     // Config codes 110xx
-    public static $modelErrorMessages = [
+    public static $configErrorMessages = [
         // Methods
         11000 => 'Undefined config exception',
         11001 => 'Missing key',

--- a/tests/XeroOauth/Config/BaseConfigTest.php
+++ b/tests/XeroOauth/Config/BaseConfigTest.php
@@ -57,16 +57,15 @@ class BaseConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Checks that constructor init methods throws Exception
-     *
-     * @expectedException \DarrynTen\XeroOauth\Exception\ConfigException
-     * @expectedExceptionCode \DarrynTen\XeroOauth\Exception\ConfigException::MISSING_KEY
      */
     public function testConstructorException()
     {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode(ConfigException::MISSING_KEY);
+        $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
+
         $reflectedClass = new ReflectionClass(BaseConfig::class);
         $constructor = $reflectedClass->getConstructor();
         $constructor->invoke($this->configMock, [ ]);
-
-        $this->expectExceptionMessage(ExceptionMessages::$modelErrorMessages[ConfigException::MISSING_KEY]);
     }
 }

--- a/tests/XeroOauth/Config/BaseConfigTest.php
+++ b/tests/XeroOauth/Config/BaseConfigTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Config;
+
+use DarrynTen\XeroOauth\Config\BaseConfig;
+use DarrynTen\XeroOauth\Exception\ConfigException;
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+use ReflectionClass;
+
+class BaseConfigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test key value
+     */
+    const TEST_KEY = 'testKey';
+
+    /**
+     * Test dummy endpoint value
+     */
+    const TEST_ENDPOINT = 'http://localhost:8082';
+
+    /**
+     * @var BaseConfig
+     */
+    private $configMock;
+
+    /**
+     * Creates mock for an abstract class
+     */
+    public function setUp()
+    {
+        $this->configMock = $this
+            ->getMockBuilder(BaseConfig::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+    }
+
+    /**
+     * Checks that constructor works well and getRequestHandlerConfig method returns right values
+     */
+    public function testGetRequestHandlerConfig()
+    {
+        $reflectedClass = new ReflectionClass(BaseConfig::class);
+        $constructor = $reflectedClass->getConstructor();
+        $constructor->invoke($this->configMock, [
+            'key' => static::TEST_KEY,
+            'endpoint' => static::TEST_ENDPOINT
+        ]);
+
+        $handlerConfig = $this->configMock->getRequestHandlerConfig();
+
+        $this->assertTrue(is_array($handlerConfig), 'Config is not an array');
+        $this->assertArrayHasKey('key', $handlerConfig, 'Config does not contain key `key`');
+        $this->assertEquals(static::TEST_KEY, $handlerConfig['key'], 'Key is wrong');
+        $this->assertArrayHasKey('endpoint', $handlerConfig, 'Config does not contain key `endpoint`');
+        $this->assertEquals(static::TEST_ENDPOINT, $handlerConfig['endpoint'], 'Endpoint is wrong');
+    }
+
+    /**
+     * Checks that constructor init methods throws Exception
+     *
+     * @expectedException \DarrynTen\XeroOauth\Exception\ConfigException
+     * @expectedExceptionCode \DarrynTen\XeroOauth\Exception\ConfigException::MISSING_KEY
+     */
+    public function testConstructorException()
+    {
+        $reflectedClass = new ReflectionClass(BaseConfig::class);
+        $constructor = $reflectedClass->getConstructor();
+        $constructor->invoke($this->configMock, [ ]);
+
+        $this->expectExceptionMessage(ExceptionMessages::$modelErrorMessages[ConfigException::MISSING_KEY]);
+    }
+}


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | yes
| New feature?      | yes
| Breaking Changes? | no
| Fixed issues      | #

## The problem
No code coverage for an abstract BaseConfig class

## How I resolved it
Created tests for an abstract BaseConfig class methods

## How to verify it
Run tests and check the result

## Notes
In process of test writing some minor issues were found and fixed:
* ConfigException had wrong namespace - fixed
* ConfigException tried to use wrong source of Error messages - fixed
* \DarrynTen\XeroOauth\Config\BaseConfig::getRequestHandlerConfig tried to return value of inexist and wrong attribute (username instead of endpoint) - fixed 

Notify the following people: @darrynten 
