### PR TITLE
All config tests

### DIFF
--- a/src/Config/BaseConfig.php
+++ b/src/Config/BaseConfig.php
@@ -7,6 +7,8 @@ use DarrynTen\XeroOauth\Exception\ConfigException;
 /**
  * XeroOauth Config
  *
+ * TODO Make public attributes protected and put them under getters/setters/__magic
+ *
  * @category Configuration
  * @package  XeroOauthPHP
  * @author   Darryn Ten <darrynten@github.com>

--- a/src/Config/PartnerApplicationConfig.php
+++ b/src/Config/PartnerApplicationConfig.php
@@ -11,8 +11,6 @@
 
 namespace DarrynTen\XeroOauth\Config;
 
-use DarrynTen\XeroOauth\BaseConfig;
-
 /**
  * Parner Application Configuration
  *

--- a/src/Config/PrivateApplicationConfig.php
+++ b/src/Config/PrivateApplicationConfig.php
@@ -11,8 +11,6 @@
 
 namespace DarrynTen\XeroOauth\Config;
 
-use DarrynTen\XeroOauth\BaseConfig;
-
 /**
  * Private Application Configuration
  *

--- a/src/Config/PublicApplicationConfig.php
+++ b/src/Config/PublicApplicationConfig.php
@@ -11,8 +11,6 @@
 
 namespace DarrynTen\XeroOauth\Config;
 
-use DarrynTen\XeroOauth\BaseConfig;
-
 /**
  * Public Application Configuration
  *

--- a/tests/XeroOauth/Config/PartnerApplicationConfigTest.php
+++ b/tests/XeroOauth/Config/PartnerApplicationConfigTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Config;
+
+use DarrynTen\XeroOauth\Config\PartnerApplicationConfig;
+use DarrynTen\XeroOauth\Exception\ConfigException;
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+
+class PartnerApplicationConfigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test key value
+     */
+    const TEST_KEY = 'testKey';
+
+    /**
+     * Test dummy endpoint value
+     */
+    const TEST_ENDPOINT = 'http://localhost:8082';
+
+    /**
+     * @var PartnerApplicationConfig
+     */
+    private $configObject;
+
+    /**
+     * Creates an instance of a test object
+     */
+    public function setUp()
+    {
+        $this->configObject = new PartnerApplicationConfig([
+            'key' => static::TEST_KEY,
+            'endpoint' => static::TEST_ENDPOINT
+        ]);
+    }
+
+    /**
+     * Checks that we have an instance of right class
+     */
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf(
+            PartnerApplicationConfig::class,
+            $this->configObject,
+            sprintf('Config must be an instance of %s', PartnerApplicationConfig::class)
+        );
+    }
+
+    /**
+     * Checks that getRequestHandlerConfig method returns right values
+     */
+    public function testGetRequestHandlerConfig()
+    {
+        $handlerConfig = $this->configObject->getRequestHandlerConfig();
+
+        $this->assertTrue(is_array($handlerConfig), 'Config is not an array');
+        $this->assertArrayHasKey('key', $handlerConfig, 'Config does not contain key `key`');
+        $this->assertEquals(static::TEST_KEY, $handlerConfig['key'], 'Key is wrong');
+        $this->assertArrayHasKey('endpoint', $handlerConfig, 'Config does not contain key `endpoint`');
+        $this->assertEquals(static::TEST_ENDPOINT, $handlerConfig['endpoint'], 'Endpoint is wrong');
+    }
+
+    /**
+     * Checks that constructor init methods throws Exception
+     */
+    public function testConstructorException()
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode(ConfigException::MISSING_KEY);
+        $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
+
+        $configObject = new PartnerApplicationConfig([ ]);
+    }
+}

--- a/tests/XeroOauth/Config/PartnerApplicationConfigTest.php
+++ b/tests/XeroOauth/Config/PartnerApplicationConfigTest.php
@@ -68,6 +68,6 @@ class PartnerApplicationConfigTest extends \PHPUnit_Framework_TestCase
         $this->expectExceptionCode(ConfigException::MISSING_KEY);
         $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
 
-        $configObject = new PartnerApplicationConfig([ ]);
+        (new PartnerApplicationConfig([ ]));
     }
 }

--- a/tests/XeroOauth/Config/PrivateApplicationConfigTest.php
+++ b/tests/XeroOauth/Config/PrivateApplicationConfigTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Config;
+
+use DarrynTen\XeroOauth\Config\PrivateApplicationConfig;
+use DarrynTen\XeroOauth\Exception\ConfigException;
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+
+class PrivateApplicationConfigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test key value
+     */
+    const TEST_KEY = 'testKey';
+
+    /**
+     * Test dummy endpoint value
+     */
+    const TEST_ENDPOINT = 'http://localhost:8082';
+
+    /**
+     * @var PrivateApplicationConfig
+     */
+    private $configObject;
+
+    /**
+     * Creates an instance of a test object
+     */
+    public function setUp()
+    {
+        $this->configObject = new PrivateApplicationConfig([
+            'key' => static::TEST_KEY,
+            'endpoint' => static::TEST_ENDPOINT
+        ]);
+    }
+
+    /**
+     * Checks that we have an instance of right class
+     */
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf(
+            PrivateApplicationConfig::class,
+            $this->configObject,
+            sprintf('Config must be an instance of %s', PrivateApplicationConfig::class)
+        );
+    }
+
+    /**
+     * Checks that getRequestHandlerConfig method returns right values
+     */
+    public function testGetRequestHandlerConfig()
+    {
+        $handlerConfig = $this->configObject->getRequestHandlerConfig();
+
+        $this->assertTrue(is_array($handlerConfig), 'Config is not an array');
+        $this->assertArrayHasKey('key', $handlerConfig, 'Config does not contain key `key`');
+        $this->assertEquals(static::TEST_KEY, $handlerConfig['key'], 'Key is wrong');
+        $this->assertArrayHasKey('endpoint', $handlerConfig, 'Config does not contain key `endpoint`');
+        $this->assertEquals(static::TEST_ENDPOINT, $handlerConfig['endpoint'], 'Endpoint is wrong');
+    }
+
+    /**
+     * Checks that constructor init methods throws Exception
+     */
+    public function testConstructorException()
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode(ConfigException::MISSING_KEY);
+        $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
+
+        $configObject = new PrivateApplicationConfig([ ]);
+    }
+}

--- a/tests/XeroOauth/Config/PrivateApplicationConfigTest.php
+++ b/tests/XeroOauth/Config/PrivateApplicationConfigTest.php
@@ -68,6 +68,6 @@ class PrivateApplicationConfigTest extends \PHPUnit_Framework_TestCase
         $this->expectExceptionCode(ConfigException::MISSING_KEY);
         $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
 
-        $configObject = new PrivateApplicationConfig([ ]);
+        (new PrivateApplicationConfig([ ]));
     }
 }

--- a/tests/XeroOauth/Config/PublicApplicationConfigTest.php
+++ b/tests/XeroOauth/Config/PublicApplicationConfigTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Config;
+
+use DarrynTen\XeroOauth\Config\PublicApplicationConfig;
+use DarrynTen\XeroOauth\Exception\ConfigException;
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+
+class PublicApplicationConfigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test key value
+     */
+    const TEST_KEY = 'testKey';
+
+    /**
+     * Test dummy endpoint value
+     */
+    const TEST_ENDPOINT = 'http://localhost:8082';
+
+    /**
+     * @var PublicApplicationConfig
+     */
+    private $configObject;
+
+    /**
+     * Creates an instance of a test object
+     */
+    public function setUp()
+    {
+        $this->configObject = new PublicApplicationConfig([
+            'key' => static::TEST_KEY,
+            'endpoint' => static::TEST_ENDPOINT
+        ]);
+    }
+
+    /**
+     * Checks that we have an instance of right class
+     */
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf(
+            PublicApplicationConfig::class,
+            $this->configObject,
+            sprintf('Config must be an instance of %s', PublicApplicationConfig::class)
+        );
+    }
+
+    /**
+     * Checks that getRequestHandlerConfig method returns right values
+     */
+    public function testGetRequestHandlerConfig()
+    {
+        $handlerConfig = $this->configObject->getRequestHandlerConfig();
+
+        $this->assertTrue(is_array($handlerConfig), 'Config is not an array');
+        $this->assertArrayHasKey('key', $handlerConfig, 'Config does not contain key `key`');
+        $this->assertEquals(static::TEST_KEY, $handlerConfig['key'], 'Key is wrong');
+        $this->assertArrayHasKey('endpoint', $handlerConfig, 'Config does not contain key `endpoint`');
+        $this->assertEquals(static::TEST_ENDPOINT, $handlerConfig['endpoint'], 'Endpoint is wrong');
+    }
+
+    /**
+     * Checks that constructor init methods throws Exception
+     */
+    public function testConstructorException()
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode(ConfigException::MISSING_KEY);
+        $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
+
+        $configObject = new PublicApplicationConfig([ ]);
+    }
+}

--- a/tests/XeroOauth/Config/PublicApplicationConfigTest.php
+++ b/tests/XeroOauth/Config/PublicApplicationConfigTest.php
@@ -68,6 +68,6 @@ class PublicApplicationConfigTest extends \PHPUnit_Framework_TestCase
         $this->expectExceptionCode(ConfigException::MISSING_KEY);
         $this->expectExceptionMessage(ExceptionMessages::$configErrorMessages[ConfigException::MISSING_KEY]);
 
-        $configObject = new PublicApplicationConfig([ ]);
+        (new PublicApplicationConfig([ ]));
     }
 }


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | yes
| New feature?      | yes
| Breaking Changes? | no
| Fixed issues      | #

## The problem
No test coverage for all the config classes

## How I resolved it
Basic tests written for all the config classes

## How to verify it
Run PHPUnit and check the coverage

## Notes
* Namespace issue for a BaseConfig class calls in all the configs - fixed
* TODO: change all the public attributes of configs to protected and put them under getters/setters/__magic
* All the tests are pretty the same. It's made just for case when you override the abstract class implementation

Notify the following people: @darrynten 
