### PR TITLE
Feature exception classes tests

### DIFF
--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -12,7 +12,6 @@
 namespace DarrynTen\XeroOauth\Exception;
 
 use Exception;
-use DarrynTen\XeroOauth\Exception\ExceptionMessages;
 
 /**
  * API exception for XeroOauth

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -12,7 +12,6 @@
 namespace DarrynTen\XeroOauth\Exception;
 
 use Exception;
-use DarrynTen\XeroOauth\Exception\ExceptionMessages;
 
 /**
  * Validation exception for XeroOauth

--- a/tests/XeroOauth/Exception/ApiExceptionTest.php
+++ b/tests/XeroOauth/Exception/ApiExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jguru
+ * Date: 14.07.17
+ * Time: 14:06
+ */
+
+namespace DarrynTen\XeroOauth\Exception;
+
+
+class ApiExceptionTest extends \PHPUnit_Framework_TestCase
+{
+
+}

--- a/tests/XeroOauth/Exception/ApiExceptionTest.php
+++ b/tests/XeroOauth/Exception/ApiExceptionTest.php
@@ -43,7 +43,7 @@ class ApiExceptionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Provides data for tests
+     * Provides data for tests: an array of arrays with structure [ code, message, expected message ]
      * @return array
      */
     public function dataProvider()

--- a/tests/XeroOauth/Exception/ApiExceptionTest.php
+++ b/tests/XeroOauth/Exception/ApiExceptionTest.php
@@ -59,7 +59,7 @@ class ApiExceptionTest extends \PHPUnit_Framework_TestCase
                 json_encode([
                     'status' => static::TEST_STATUS,
                     'title' => static::TEST_MESSAGE,
-                    'detail' => static::TEST_DETAIL
+                    'detail' => static::TEST_DETAIL,
                 ]),
                 sprintf(
                     "%s: %s - %s",
@@ -75,7 +75,7 @@ class ApiExceptionTest extends \PHPUnit_Framework_TestCase
                     'title' => static::TEST_MESSAGE,
                     'detail' => static::TEST_DETAIL,
                     'errors' => [
-                        static::TEST_ADDITIONAL
+                        static::TEST_ADDITIONAL,
                     ]
                 ]),
                 sprintf(
@@ -84,7 +84,7 @@ class ApiExceptionTest extends \PHPUnit_Framework_TestCase
                     static::TEST_MESSAGE,
                     static::TEST_DETAIL,
                     json_encode([
-                        static::TEST_ADDITIONAL
+                        static::TEST_ADDITIONAL,
                     ])
                 )
             ],

--- a/tests/XeroOauth/Exception/ApiExceptionTest.php
+++ b/tests/XeroOauth/Exception/ApiExceptionTest.php
@@ -1,15 +1,93 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jguru
- * Date: 14.07.17
- * Time: 14:06
- */
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Exception;
 
-namespace DarrynTen\XeroOauth\Exception;
-
+use DarrynTen\XeroOauth\Exception\ApiException;
 
 class ApiExceptionTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Test message or title
+     */
+    const TEST_MESSAGE = 'Test error';
 
+    /**
+     * Test status for Exception
+     */
+    const TEST_STATUS = 'Error';
+
+    /**
+     * Test details for Exception
+     */
+    const TEST_DETAIL = 'Something went wrong';
+
+    /**
+     * Test additional information for Exception
+     */
+    const TEST_ADDITIONAL = 'But that`s not certain';
+
+    /**
+     * Tests if exception is valid: class, code, message
+     * @dataProvider dataProvider
+     * @param $code
+     * @param $message
+     * @param $expected
+     * @throws ApiException
+     */
+    public function testConstructor($code, $message, $expected)
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode($code);
+        $this->expectExceptionMessage($expected);
+
+        throw new ApiException($message, $code);
+    }
+
+    /**
+     * Provides data for tests
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return [
+            [
+                1,
+                static::TEST_MESSAGE,
+                static::TEST_MESSAGE,
+            ],
+            [
+                2,
+                json_encode([
+                    'status' => static::TEST_STATUS,
+                    'title' => static::TEST_MESSAGE,
+                    'detail' => static::TEST_DETAIL
+                ]),
+                sprintf(
+                    "%s: %s - %s",
+                    static::TEST_STATUS,
+                    static::TEST_MESSAGE,
+                    static::TEST_DETAIL
+                )
+            ],
+            [
+                3,
+                json_encode([
+                    'status' => static::TEST_STATUS,
+                    'title' => static::TEST_MESSAGE,
+                    'detail' => static::TEST_DETAIL,
+                    'errors' => [
+                        static::TEST_ADDITIONAL
+                    ]
+                ]),
+                sprintf(
+                    "%s: %s - %s - errors: %s",
+                    static::TEST_STATUS,
+                    static::TEST_MESSAGE,
+                    static::TEST_DETAIL,
+                    json_encode([
+                        static::TEST_ADDITIONAL
+                    ])
+                )
+            ],
+        ];
+    }
 }

--- a/tests/XeroOauth/Exception/ConfigExceptionTest.php
+++ b/tests/XeroOauth/Exception/ConfigExceptionTest.php
@@ -7,7 +7,7 @@ use DarrynTen\XeroOauth\Exception\ExceptionMessages;
 class ConfigExceptionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Extra string in Config message
+     * Extra string in Config Exception message
      */
     const EXTRA = 'extra';
 
@@ -65,7 +65,7 @@ class ConfigExceptionTest extends \PHPUnit_Framework_TestCase
             [
                 ConfigException::UNDEFINED_CONFIG_EXCEPTION,
                 ExceptionMessages::$configErrorMessages[ ConfigException::UNDEFINED_CONFIG_EXCEPTION ]
-            ]
+            ],
         ];
     }
 }

--- a/tests/XeroOauth/Exception/ConfigExceptionTest.php
+++ b/tests/XeroOauth/Exception/ConfigExceptionTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Exception;
+
+use DarrynTen\XeroOauth\Exception\ConfigException;
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+
+class ConfigExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Extra string in Config message
+     */
+    const EXTRA = 'extra';
+
+    /**
+     * Tests if exception is valid: class, code, message
+     * @dataProvider dataProvider
+     * @param $code
+     * @param $message
+     * @throws ConfigException
+     */
+    public function testConstructor($code, $message)
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode($code);
+        $this->expectExceptionMessageRegExp(
+            sprintf("/%s$/", $message)
+        );
+
+        throw new ConfigException($code);
+    }
+
+    /**
+     * Tests if exception is valid with extra argument: class, code, message
+     * @dataProvider dataProvider
+     * @param $code
+     * @param $message
+     * @throws ConfigException
+     */
+    public function testConstructorWithExtra($code, $message)
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode($code);
+        $this->expectExceptionMessageRegExp(
+            sprintf(
+                "/%s %s$/",
+                static::EXTRA,
+                $message
+            )
+        );
+
+        throw new ConfigException($code, static::EXTRA);
+    }
+
+    /**
+     * Provides data for tests
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return [
+            [
+                ConfigException::MISSING_KEY,
+                ExceptionMessages::$configErrorMessages[ ConfigException::MISSING_KEY ]
+            ],
+            [
+                ConfigException::UNDEFINED_CONFIG_EXCEPTION,
+                ExceptionMessages::$configErrorMessages[ ConfigException::UNDEFINED_CONFIG_EXCEPTION ]
+            ]
+        ];
+    }
+}

--- a/tests/XeroOauth/Exception/ValidationExceptionTest.php
+++ b/tests/XeroOauth/Exception/ValidationExceptionTest.php
@@ -7,7 +7,7 @@ use DarrynTen\XeroOauth\Exception\ValidationException;
 class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Extra string in Validation message
+     * Extra string in Validation Exception message
      */
     const EXTRA = 'extra';
 
@@ -20,7 +20,9 @@ class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionCode(ValidationException::UNDEFINED_VALIDATION_EXCEPTION);
         $this->expectExceptionMessageRegExp(
-            sprintf("/%s$/", ExceptionMessages::$validationMessages[ ValidationException::UNDEFINED_VALIDATION_EXCEPTION ])
+            sprintf("/%s$/", ExceptionMessages::$validationMessages[
+                ValidationException::UNDEFINED_VALIDATION_EXCEPTION
+            ])
         );
 
         throw new ValidationException(ValidationException::UNDEFINED_VALIDATION_EXCEPTION);
@@ -38,7 +40,9 @@ class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
             sprintf(
                 "/%s %s$/",
                 static::EXTRA,
-                ExceptionMessages::$validationMessages[ ValidationException::UNDEFINED_VALIDATION_EXCEPTION ]
+                ExceptionMessages::$validationMessages[
+                    ValidationException::UNDEFINED_VALIDATION_EXCEPTION
+                ]
             )
         );
 

--- a/tests/XeroOauth/Exception/ValidationExceptionTest.php
+++ b/tests/XeroOauth/Exception/ValidationExceptionTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Exception;
+
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+use DarrynTen\XeroOauth\Exception\ValidationException;
+
+class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Extra string in Validation message
+     */
+    const EXTRA = 'extra';
+
+    /**
+     * Tests if exception is valid: class, code, message
+     * @throws ValidationException
+     */
+    public function testConstructor()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionCode(ValidationException::UNDEFINED_VALIDATION_EXCEPTION);
+        $this->expectExceptionMessageRegExp(
+            sprintf("/%s$/", ExceptionMessages::$validationMessages[ ValidationException::UNDEFINED_VALIDATION_EXCEPTION ])
+        );
+
+        throw new ValidationException(ValidationException::UNDEFINED_VALIDATION_EXCEPTION);
+    }
+
+    /**
+     * Tests if exception is valid with extra argument: class, code, message
+     * @throws ValidationException
+     */
+    public function testConstructorWithExtra()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionCode(ValidationException::UNDEFINED_VALIDATION_EXCEPTION);
+        $this->expectExceptionMessageRegExp(
+            sprintf(
+                "/%s %s$/",
+                static::EXTRA,
+                ExceptionMessages::$validationMessages[ ValidationException::UNDEFINED_VALIDATION_EXCEPTION ]
+            )
+        );
+
+        throw new ValidationException(ValidationException::UNDEFINED_VALIDATION_EXCEPTION, static::EXTRA);
+    }
+}


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | no
| New feature?      | yes
| Breaking Changes? | no
| Fixed issues      | #

## The problem
No test coverage for Exception classes

## How I resolved it
Wrote tests for all the Exception classes except ExceptionMessages

## How to verify it
Run tests and check coverage

## Notes
* ExceptionMessages class was not covered because it has no public methods
* Unused `use` states were removed form ConfigException and ValidationException

Notify the following people: @darrynten 
