### PR TITLE
ConfigFactory added

### DIFF
--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * XeroOauth Library
+ *
+ * @category Library
+ * @package  XeroOauth
+ * @author   Darryn Ten <darrynten@github.com>
+ * @license  MIT <https://github.com/darrynten/xero-oauth-php/blob/master/LICENSE>
+ * @link     https://github.com/darrynten/xero-oauth-php
+ */
+
+namespace DarrynTen\XeroOauth\Config;
+
+use DarrynTen\XeroOauth\Exception\ConfigException;
+
+class ConfigFactory
+{
+    /**
+     * Value for Public Application type
+     */
+    const APPLICATION_TYPE_PUBLIC = 'public';
+    /**
+     * Value for Private Application type
+     */
+    const APPLICATION_TYPE_PRIVATE = 'private';
+    /**
+     * Value for Partner Application type
+     */
+    const APPLICATION_TYPE_PARTNER = 'partner';
+
+    /**
+     * Mar of dependencies between type values and classes
+     * @var array
+     */
+    static private $map = [
+        self::APPLICATION_TYPE_PUBLIC => PublicApplicationConfig::class,
+        self::APPLICATION_TYPE_PRIVATE => PrivateApplicationConfig::class,
+        self::APPLICATION_TYPE_PARTNER => PartnerApplicationConfig::class
+    ];
+
+    /**
+     * Creates an instance of config class
+     * @param array $config
+     * @return BaseConfig
+     * @throws ConfigException
+     */
+    public function getConfig(array $config)
+    {
+        if (!isset($config['applicationType']) || empty($config['applicationType'])) {
+            throw new ConfigException(ConfigException::MISSING_APPLICATION_TYPE);
+        }
+
+        if (!array_key_exists($config['applicationType'], static::$map)) {
+            throw new ConfigException(ConfigException::UNKNOWN_APPLICATION_TYPE, $config['applicationType']);
+        }
+
+        return new static::$map[ $config[ 'applicationType' ] ]($config);
+    }
+}

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -4,7 +4,7 @@
  *
  * @category Library
  * @package  XeroOauth
- * @author   Darryn Ten <darrynten@github.com>
+ * @author   Mikhail Levanov <leor.thesweetvoice@gmail.com>
  * @license  MIT <https://github.com/darrynten/xero-oauth-php/blob/master/LICENSE>
  * @link     https://github.com/darrynten/xero-oauth-php
  */
@@ -19,10 +19,12 @@ class ConfigFactory
      * Value for Public Application type
      */
     const APPLICATION_TYPE_PUBLIC = 'public';
+
     /**
      * Value for Private Application type
      */
     const APPLICATION_TYPE_PRIVATE = 'private';
+
     /**
      * Value for Partner Application type
      */

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -34,7 +34,7 @@ class ConfigFactory
      * Mar of dependencies between type values and classes
      * @var array
      */
-    static private $map = [
+    private static $map = [
         self::APPLICATION_TYPE_PUBLIC => PublicApplicationConfig::class,
         self::APPLICATION_TYPE_PRIVATE => PrivateApplicationConfig::class,
         self::APPLICATION_TYPE_PARTNER => PartnerApplicationConfig::class

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -22,7 +22,9 @@ class ConfigException extends Exception
 {
     const UNDEFINED_CONFIG_EXCEPTION = 11000;
     const MISSING_KEY = 11001;
-    // number constants up from this number - 11002 is next
+    const MISSING_APPLICATION_TYPE = 11002;
+    const UNKNOWN_APPLICATION_TYPE = 11003;
+    // number constants up from this number - 11004 is next
 
     /**
      * Custom validation exception handler

--- a/src/Exception/ExceptionMessages.php
+++ b/src/Exception/ExceptionMessages.php
@@ -12,6 +12,8 @@ class ExceptionMessages
         // Methods
         11000 => 'Undefined config exception',
         11001 => 'Missing key',
+        11002 => 'Missing application type',
+        11003 => 'Unknown application type'
     ];
 
     // Validation codes 111xx

--- a/tests/XeroOauth/Config/ConfigFactoryTest.php
+++ b/tests/XeroOauth/Config/ConfigFactoryTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace DarrynTen\XeroOauth\Tests\XeroOauth\Config;
+
+use DarrynTen\XeroOauth\Config\ConfigFactory;
+use DarrynTen\XeroOauth\Config\PartnerApplicationConfig;
+use DarrynTen\XeroOauth\Config\PrivateApplicationConfig;
+use DarrynTen\XeroOauth\Config\PublicApplicationConfig;
+use DarrynTen\XeroOauth\Exception\ConfigException;
+use DarrynTen\XeroOauth\Exception\ExceptionMessages;
+
+class ConfigFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ConfigFactory
+     */
+    private $configFactory;
+
+    /**
+     * Creates an instance of testing object
+     */
+    public function setUp()
+    {
+        $this->configFactory = new ConfigFactory();
+    }
+
+    /**
+     * Checks if instance is of right class
+     */
+    public function testInstanceOf()
+    {
+        $this->assertEquals(
+            ConfigFactory::class,
+            get_class($this->configFactory),
+            sprintf('Factory must be instance of %s', ConfigFactory::class)
+        );
+    }
+
+    /**
+     * Checks that right Exception was thrown in case of not set applicationType
+     */
+    public function testGetConfigNoApplicationType()
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode(ConfigException::MISSING_APPLICATION_TYPE);
+        $this->expectExceptionMessage(
+            ExceptionMessages::$configErrorMessages[ ConfigException::MISSING_APPLICATION_TYPE ]
+        );
+
+        $this->configFactory->getConfig([ ]);
+    }
+
+    /**
+     * Checks that right Exception was thrown in case of unknown applicationType
+     */
+    public function testGetConfigUnknownApplicationType()
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionCode(ConfigException::UNKNOWN_APPLICATION_TYPE);
+        $this->expectExceptionMessage(
+            ExceptionMessages::$configErrorMessages[ ConfigException::UNKNOWN_APPLICATION_TYPE ]
+        );
+
+        $this->configFactory->getConfig([
+            'applicationType' => 'unknown'
+        ]);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     * @param $applicationType
+     * @param $expectedClass
+     */
+    public function testGetConfig($applicationType, $expectedClass)
+    {
+        $config = $this->configFactory->getConfig([
+            'applicationType' => $applicationType,
+            'key' => 'test'
+        ]);
+
+        $this->assertInstanceOf(
+            $expectedClass,
+            $config,
+            sprintf(
+                "Config must be an instance of %s",
+                $expectedClass
+            )
+        );
+    }
+
+    /**
+     * Provides test with data
+     * $array = [
+     *   $applicationType,
+     *   $expectedClass,
+     * ]
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return [
+            [
+                ConfigFactory::APPLICATION_TYPE_PUBLIC,
+                PublicApplicationConfig::class,
+            ],
+            [
+                ConfigFactory::APPLICATION_TYPE_PRIVATE,
+                PrivateApplicationConfig::class,
+            ],
+            [
+                ConfigFactory::APPLICATION_TYPE_PARTNER,
+                PartnerApplicationConfig::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | no
| New feature?      | yes
| Breaking Changes? | no
| Fixed issues      | #

## The problem
We have no way to create proper instance of config object

## How I resolved it
ConfigFactory created. It can produce proper config object using the `applicationType` option from a $config array

## How to verify it
Run tests

## Notes
We need this to run main class XeroOauth

Notify the following people: @darrynten 
